### PR TITLE
Pin to more recent nbsite

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ extras_require = {
     'tests': tests,
     'examples': examples,
     'doc': examples + [
-        'nbsite',
+        'nbsite >=0.6.1',
         'sphinx_ioam_theme',
     ],
     'tests_extra': tests + [


### PR DESCRIPTION
The docs looked spectacularly broken when they rendered with an old version of nbsite:

<img width="1499" alt="Screen Shot 2019-08-28 at 4 10 45 PM" src="https://user-images.githubusercontent.com/4806877/63889231-91da3500-c9ae-11e9-9f09-e181deb282ed.png">

This is because old versions of nbsite didn't add the .nojekyll file that is needed to allow css to work properly.