### PR TITLE
Update swatch to explicitly check if cmap has a tuple type

### DIFF
--- a/colorcet/plotting.py
+++ b/colorcet/plotting.py
@@ -19,7 +19,8 @@ def swatch(name, cmap=None, bounds=None, array=array, **kwargs):
     if bounds is None:
         bounds = (0, 0, 256, 1)
 
-    cmap = list(cmap) if cmap is not None else None
+    if type(cmap) is tuple:
+        cmap = list(cmap)
 
     plot = hv.Image(array, bounds=bounds, group=title)
     backends = hv.Store.loaded_backends()


### PR DESCRIPTION
@jlstevens @philippjfr 

A small PR updating to only convert cmap in swatch() to a list if it has a tuple type.