### PR TITLE
Disables interactivity warning on homepage

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,6 +9,7 @@
 
 .. notebook:: colorcet ../examples/index.ipynb
     :offset: 0
+    :disable_interactivity_warning:
 
 .. toctree::
     :hidden:


### PR DESCRIPTION
Disables the interactivity warning when built with the notebook directive in the latest nbsite version.