### PR TITLE
pytest on gh actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,79 @@
+name: pytest
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test_suite:
+    name: Pytest on ${{ matrix.python-version }}, ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        python-version: [2.7, 3.5, 3.6, 3.7]  # 3.6 and 3.7 works
+        # exclude:
+        #   - os: windows-latest
+        #     python-version: 2.7
+        #   - os: macos-latest
+        #     python-version: 3.7
+    timeout-minutes: 60
+    defaults:
+      run:
+        shell: bash -l {0} 
+    env:
+      HV_REQUIREMENTS: "examples"
+      PYTHON_VERSION: ${{ matrix.python-version }}
+      CHANS_DEV: "-c pyviz/label/dev"
+      # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ENV_NAME: "colorcet"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "100"
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: "latest"
+      - name: conda setup
+        run: |
+          conda config --set always_yes True
+          conda --version
+          conda install -c pyviz "pyctdev>=0.5"
+          doit ecosystem_setup
+          doit env_create --name=${{ env.ENV_NAME }} --python=${{ matrix.python-version }}
+          conda --version
+      - name: doit develop_install
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate ${{ env.ENV_NAME }}
+          conda --version
+          doit develop_install ${{ env.CHANS_DEV}} -o ${{ env.HV_REQUIREMENTS }}
+          conda list
+      - name: doit env_capture
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate ${{ env.ENV_NAME }}
+          doit env_capture
+      - name: conda list
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate ${{ env.ENV_NAME }}
+          conda list
+      - name: doit test_all
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate ${{ env.ENV_NAME }}
+          doit test_all
+      - name: doit test_unit_extra
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate ${{ env.ENV_NAME }}
+          pip install pytest-mpl
+          doit test_unit_extra

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,105 +1,105 @@
-language: generic
+# language: generic
 
-env:
-  global:
-    - CHANS_DEV="-c pyviz/label/dev"
-    - CHANS_REL="-c pyviz"
-    - LABELS_DEV="--label dev"
-    - LABELS_REL="--label dev --label main"
-    - PYENV_VERSION=3.7.1
-    - PKG_TEST_PYTHON="--test-python=py37 --test-python=py27"
+# env:
+#   global:
+#     - CHANS_DEV="-c pyviz/label/dev"
+#     - CHANS_REL="-c pyviz"
+#     - LABELS_DEV="--label dev"
+#     - LABELS_REL="--label dev --label main"
+#     - PYENV_VERSION=3.7.1
+#     - PKG_TEST_PYTHON="--test-python=py37 --test-python=py27"
 
-stages:
-  - test
-  - name: conda_dev_package
-    if: tag =~ ^v(\d+|\.)+[a-z]\d+$
-  - name: pip_dev_package
-    if: tag =~ ^v(\d+|\.)+[a-z]\d+$
-  - name: conda_package
-    if: tag =~ ^v(\d+|\.)+[^a-z]\d+$
-  - name: pip_package
-    if: tag =~ ^v(\d+|\.)+[^a-z]\d+$
-  - name: website_dev
-    if: tag =~ ^v(\d+|\.)+[a-z]\d+$ OR tag = website_dev
-  - name: website_release
-    if: tag =~ ^v(\d+|\.)+[^a-z]\d+$ OR tag = website
+# stages:
+#   - test
+#   - name: conda_dev_package
+#     if: tag =~ ^v(\d+|\.)+[a-z]\d+$
+#   - name: pip_dev_package
+#     if: tag =~ ^v(\d+|\.)+[a-z]\d+$
+#   - name: conda_package
+#     if: tag =~ ^v(\d+|\.)+[^a-z]\d+$
+#   - name: pip_package
+#     if: tag =~ ^v(\d+|\.)+[^a-z]\d+$
+#   - name: website_dev
+#     if: tag =~ ^v(\d+|\.)+[a-z]\d+$ OR tag = website_dev
+#   - name: website_release
+#     if: tag =~ ^v(\d+|\.)+[^a-z]\d+$ OR tag = website
 
-jobs:
-  include:
-    - &default
-      stage: test
-      os: linux
-      install:
-        - pip install pyctdev && doit miniconda_install && pip uninstall -y doit pyctdev
-        - export PATH="$HOME/miniconda/bin:$PATH" && hash -r
-        - conda config --set always_yes True
-        - conda install -c pyviz pyctdev && doit ecosystem_setup
-      before_script:
-        - doit env_create --name=colorcet --python=$PYENV_VERSION
-        - source activate colorcet
-        - doit develop_install $CHANS_DEV -o examples
-        - doit env_capture
-      script:
-        - doit test_all
+# jobs:
+#   include:
+#     - &default
+#       stage: test
+#       os: linux
+#       install:
+#         - pip install pyctdev && doit miniconda_install && pip uninstall -y doit pyctdev
+#         - export PATH="$HOME/miniconda/bin:$PATH" && hash -r
+#         - conda config --set always_yes True
+#         - conda install -c pyviz pyctdev && doit ecosystem_setup
+#       before_script:
+#         - doit env_create --name=colorcet --python=$PYENV_VERSION
+#         - source activate colorcet
+#         - doit develop_install $CHANS_DEV -o examples
+#         - doit env_capture
+#       script:
+#         - doit test_all
 
 
-    - &website
-      <<: *default
-      stage: website_release
-      script:
-        # TODO: set chans according to dev/rel
-        - doit develop_install $CHANS_DEV -o doc -o examples
-        - doit build_website
+#     - &website
+#       <<: *default
+#       stage: website_release
+#       script:
+#         # TODO: set chans according to dev/rel
+#         - doit develop_install $CHANS_DEV -o doc -o examples
+#         - doit build_website
 
-      deploy:
-        - provider: pages
-          skip_cleanup: true
-          github_token: $GITHUB_TOKEN
-          local_dir: ./builtdocs
-          fqdn: colorcet.holoviz.org
-          on:
-            tags: true
-            all_branches: true
+#       deploy:
+#         - provider: pages
+#           skip_cleanup: true
+#           github_token: $GITHUB_TOKEN
+#           local_dir: ./builtdocs
+#           fqdn: colorcet.holoviz.org
+#           on:
+#             tags: true
+#             all_branches: true
 
-    - <<: *website
-      stage: website_dev
-      deploy:
-        - provider: pages
-          skip_cleanup: true
-          github_token: $GITHUB_TOKEN
-          local_dir: ./builtdocs
-          repo: pyviz-dev/colorcet
-          on:
-            tags: true
-            all_branches: true
+#     - <<: *website
+#       stage: website_dev
+#       deploy:
+#         - provider: pages
+#           skip_cleanup: true
+#           github_token: $GITHUB_TOKEN
+#           local_dir: ./builtdocs
+#           repo: pyviz-dev/colorcet
+#           on:
+#             tags: true
+#             all_branches: true
 
-    ## dev packages
+#     ## dev packages
 
-    - &pip_pkg
-      env: PYPI=testpypi PYPIUSER=$TPPU PYPIPASS=$TPPP
-      stage: pip_dev_package
-      install: pip install pyctdev && doit ecosystem=pip ecosystem_setup
-      before_script:
-        - doit ecosystem=pip package_build $PKG_TEST_PYTHON --test-group=unit --sdist-install-build-deps
-      script: doit ecosystem=pip package_upload -u $PYPIUSER -p $PYPIPASS --pypi ${PYPI}
+#     - &pip_pkg
+#       env: PYPI=testpypi PYPIUSER=$TPPU PYPIPASS=$TPPP
+#       stage: pip_dev_package
+#       install: pip install pyctdev && doit ecosystem=pip ecosystem_setup
+#       before_script:
+#         - doit ecosystem=pip package_build $PKG_TEST_PYTHON --test-group=unit --sdist-install-build-deps
+#       script: doit ecosystem=pip package_upload -u $PYPIUSER -p $PYPIPASS --pypi ${PYPI}
 
-    - &conda_pkg
-      <<: *default
-      stage: conda_dev_package
-      env: LABELS=$LABELS_DEV CHANS=$CHANS_DEV
-      before_script:
-        - travis_wait 60 doit package_build $CHANS $PKG_TEST_PYTHON --test-group=unit
-      script: doit package_upload --token=$ANACONDA_TOKEN $LABELS
+#     - &conda_pkg
+#       <<: *default
+#       stage: conda_dev_package
+#       env: LABELS=$LABELS_DEV CHANS=$CHANS_DEV
+#       before_script:
+#         - travis_wait 60 doit package_build $CHANS $PKG_TEST_PYTHON --test-group=unit
+#       script: doit package_upload --token=$ANACONDA_TOKEN $LABELS
 
-    ## release packages
+#     ## release packages
 
-    - <<: *pip_pkg
-      env: PYPI=pypi PYPIUSER=$PPU PYPIPASS=$PPP
-      stage: pip_package
+#     - <<: *pip_pkg
+#       env: PYPI=pypi PYPIUSER=$PPU PYPIPASS=$PPP
+#       stage: pip_package
 
-    - <<: *conda_pkg
-      stage: conda_package
-      env: LABELS=$LABELS_REL CHANS=$CHANS_REL
+#     - <<: *conda_pkg
+#       stage: conda_package
+#       env: LABELS=$LABELS_REL CHANS=$CHANS_REL
 
-notifications:
-  email: false
+# notifications:
+#   email: false

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ extras_require = {
         'sphinx_holoviz_theme',
     ],
     'tests_extra': tests + [
-        'pytest-mpl'  # only available on pip and conda-forge
+        'pytest-mpl',  # only available on pip and conda-forge
     ],
     # until pyproject.toml/equivalent is widely supported (setup_requires
     # doesn't work well with pip)


### PR DESCRIPTION
@jbednar @philippjfr I could use some feedback on this PR. I believe pytest was only run on Linux 3.7. I've opened it up to all platforms/versions so its possible that some of these are known issues that I should avoid. 

**Current status:**  
Python 3.6 - PASS  
Python 3.7 - PASS  

Python 2.7, Ubuntu  
Some failures looking for DISPLAY env var: `Invalid DISPLAY variable` 
https://github.com/kcpevey/colorcet/pull/1/checks?check_run_id=2042433951#step:9:489Which I could set... but if you look at the code block where the failure is, its thinking that the ubuntu 2.7 build is X11 and its part of a qt5 backend. Which just seems wrong is several different ways. Should I just set the variable it wants or dig into why its getting there in the first place?

I see this failure on all 2.7 architectures
https://github.com/kcpevey/colorcet/pull/1/checks?check_run_id=2042433951#step:9:502
Seems like the codebase is not actually supported on 2.7? It would be an easy fix to swap these around though. Should add that in as well?

For python 3.5 I'm seeing this:
```CondaUpgradeError: This environment has previously been operated on by a conda version that's newer than the conda currently being used. A newer version of conda is required.

  target environment location: C:\Miniconda3\envs\colorcet
  current conda version: 4.5.11
  minimum conda version: 4.9
```
I did some initial googling about this, but I haven't worked out a solution (or what the problem is, actually). 