### PR TITLE
Add a few packages required for the pip build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,9 @@ tests = [
     'nbsmoke >=0.2.6',
     'pytest >=2.8.5',
     'pytest-cov',
+    'twine',   # required for pip packaging
+    'rfc3986', # required by twine
+    'keyring', # required by twine
 ]
 
 extras_require = {


### PR DESCRIPTION
I've seen that these packages are required for the pip build while working on releasing nbsmoke.