### PR TITLE
Remove freetype pinned version in the CI test suite

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,12 +51,6 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate ${{ env.ENV_NAME }}
           doit develop_install ${{ env.CHANS}} -o ${{ env.HV_REQUIREMENTS }}
-      - name: Patch with an older version of freetype since 2.11.0 is broken with Matplotlib on Windows
-        if: (matrix.os == 'windows-latest')
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate ${{ env.ENV_NAME }}
-          conda install ${{ env.CHANS}} "freetype=2.10.4"
       - name: doit env_capture
         run: |
           eval "$(conda shell.bash hook)"


### PR DESCRIPTION
Merge it in a few weeks, once there is a version of freetype that doesn't cause matplotlib to fail on Windows.