### PR TITLE
Depend on appropriate pyct extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "pyct >=0.4.4",
+    "pyct[build,cmd] >=0.4.4",
     "param >=1.7.0",
     "setuptools >=30.3.0",
     "wheel",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def get_setup_version(reponame):
 
 install_requires = [
     'param >=1.7.0',
-    'pyct >=0.4.4',
+    'pyct[cmd] >=0.4.4',
 ]
 
 examples = [
@@ -62,7 +62,7 @@ extras_require = {
     # doesn't work well with pip)
     'build': [
         'param >=1.7.0',
-        'pyct >=0.4.4',
+        'pyct[build,cmd] >=0.4.4',
         'setuptools >=30.3.0',
         'wheel',
     ]


### PR DESCRIPTION
Change the `install_requires` on `pyct` to `pyct[cmd]`, and the build dependencies to `pyct[build,cmd]`, in order to ensure that the appropriate optional/extra dependencies of `pyct` are installed.

This fixes the following problem:

```
$ python3 -m venv _e
$ . _e/bin/activate
(_e) $ pip install colorcet
Collecting colorcet
  Using cached colorcet-2.0.6-py2.py3-none-any.whl (1.6 MB)
Collecting pyct>=0.4.4
  Using cached pyct-0.4.8-py2.py3-none-any.whl (15 kB)
Collecting param>=1.7.0
  Using cached param-1.12.0-py2.py3-none-any.whl (85 kB)
Installing collected packages: param, pyct, colorcet
Successfully installed colorcet-2.0.6 param-1.12.0 pyct-0.4.8
(_e) $ colorcet --help
Traceback (most recent call last):
  File "[…]/_e/lib64/python3.10/site-packages/colorcet/__main__.py", line 3, in main
    import pyct.cmd
  File "[…]/_e/lib64/python3.10/site-packages/pyct/cmd.py", line 81, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "[…]/_e/bin/colorcet", line 8, in <module>
    sys.exit(main())
  File "[…]/_e/lib64/python3.10/site-packages/colorcet/__main__.py", line 6, in main
    from . import _missing_cmd
ImportError: cannot import name '_missing_cmd' from 'colorcet' (…/_e/lib64/python3.10/site-packages/colorcet/__init__.py)
```

(Well—it fixes the `ModuleNotFoundError`. The nonexistence of `_missing_cmd` is a separate issue.)