### PR TITLE
Use license_files instead of the deprecated license_file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup_args = dict(
     version=get_setup_version('colorcet'),
     long_description='README.md',
     long_description_type='text/markdown',
-    license_file='LICENSE.txt',
+    license_files=['LICENSE.txt'],
     license='CC-BY License',
     classifiers=[
         "License :: OSI Approved",


### PR DESCRIPTION
The setuptools `license_file` key is [deprecated](https://setuptools.pypa.io/en/latest/deprecated/changed_keywords.html?highlight=license_files#new-and-changed-setup-keywords). Use `license_files` instead, that accept a list of license files.