### PR TITLE
Fix typos

### DIFF
--- a/colorcet/sineramp.py
+++ b/colorcet/sineramp.py
@@ -22,7 +22,7 @@ Usage: im = sineramp(sze, amp, wavelen, p)
 Arguments:     sze - [rows cols] specifying size of test image.  If a
                      single value is supplied the image is square.
                      Defaults to [256 512];  Note the number of columns is
-                     nominal and will be ajusted so that there are an
+                     nominal and will be adjusted so that there are an
                      integer number of sine wave cycles across the image.
                amp - Amplitude of sine wave. Defaults to 12.5
            wavelen - Wavelength of sine wave in pixels. Defaults to 8.

--- a/colorcet/version.py
+++ b/colorcet/version.py
@@ -142,7 +142,7 @@ class Version(object):
 
     @property
     def dirty(self):
-        "True if there are uncommited changes, False otherwise"
+        "True if there are uncommitted changes, False otherwise"
         return self.fetch()._dirty
 
 
@@ -610,7 +610,7 @@ class OldDeprecatedVersion(object):
 
     @property
     def dirty(self):
-        "True if there are uncommited changes, False otherwise"
+        "True if there are uncommitted changes, False otherwise"
         return self.fetch()._dirty
 
 

--- a/examples/index.ipynb
+++ b/examples/index.ipynb
@@ -7,7 +7,7 @@
     "## Collection of perceptually accurate colormaps\n",
     "\n",
     "[Colorcet](https://github.com/holoviz/colorcet) is a collection of \n",
-    "perceptually acccurate 256-color colormaps for use with Python plotting programs like\n",
+    "perceptually accurate 256-color colormaps for use with Python plotting programs like\n",
     "[Bokeh](https://docs.bokeh.org),\n",
     "[Matplotlib](https://matplotlib.org),\n",
     "[HoloViews](https://holoviews.org), and\n",


### PR DESCRIPTION
Found via `codespell -S ./assets -L als,trough`