### PR TITLE
Update check to use matplotlib version instead of python version

### DIFF
--- a/colorcet/tests/test_matplotlib.py
+++ b/colorcet/tests/test_matplotlib.py
@@ -2,6 +2,7 @@ import sys
 
 import pytest
 import colorcet as cc
+from packaging.version import Version
 
 pytest.importorskip('matplotlib')
 
@@ -46,7 +47,9 @@ def test_matplotlib_default_colormap_plot_kbc():
 
 @pytest.mark.parametrize('k,v', list(cc.cm.items()))
 def test_get_cm(k, v):
-    if sys.version_info < (3, 7):
+    import matplotlib as mpl
+
+    if Version(mpl.__version__) < Version("3.5"):
         import matplotlib.cm as mcm
         assert mcm.get_cmap('cet_' + k) is v
     else:

--- a/colorcet/tests/test_matplotlib.py
+++ b/colorcet/tests/test_matplotlib.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 import colorcet as cc
 from packaging.version import Version

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ tests = [
     'nbsmoke >=0.2.6',
     'pytest >=2.8.5',
     'pytest-cov',
+    'packaging',
 ]
 
 extras_require = {


### PR DESCRIPTION
Fixes #103

The test would fail when having matplotlib version 3.4 and below installed. 

