### PR TITLE
Only register if cmap not in colormaps

### DIFF
--- a/colorcet/__init__.py
+++ b/colorcet/__init__.py
@@ -62,7 +62,10 @@ try:
     from matplotlib.colors import LinearSegmentedColormap, ListedColormap
     try:
         from matplotlib import colormaps
-        register_cmap = lambda name, cmap: colormaps.register(cmap, name=name)
+        def register_cmap(name, cmap):
+            if name not in colormaps or colormaps[name] != cmap:
+                # The last condition will raise an error
+                colormaps.register(cmap, name=name)
     except ImportError:
         # PendingDeprecationWarning from matplotlib 3.6
         from matplotlib.cm import register_cmap

--- a/colorcet/tests/test_matplotlib.py
+++ b/colorcet/tests/test_matplotlib.py
@@ -71,7 +71,6 @@ def test_register_cmap():
     cc.register_cmap(name, cmap1)
 
     # Not same values should raise an Error
-    with pytest.raises(
-        ValueError, match=f'A colormap named "{name}" is already registered'
-    ):
+    msg = 'A colormap named "{}" is already registered'.format(name)
+    with pytest.raises(ValueError, match=msg):
         cc.register_cmap(name, cmap2)

--- a/colorcet/tests/test_matplotlib.py
+++ b/colorcet/tests/test_matplotlib.py
@@ -53,3 +53,25 @@ def test_get_cm(k, v):
     else:
         from matplotlib import colormaps
         assert colormaps['cet_' + k] == v
+
+
+def test_register_cmap():
+    import matplotlib as mpl
+    if Version(mpl.__version__) < Version("3.5"):
+        return
+
+    cmap0 = cc.ListedColormap([[0, 0, 0], [1, 1, 1]])
+    cmap1 = cc.ListedColormap([[0, 0, 0], [1, 1, 1]])
+    cmap2 = cc.ListedColormap([[1, 1, 1], [0, 0, 0]])
+
+    name = "test_long_random_name_just_to_be_sure"
+    cc.register_cmap(name, cmap0)
+
+    # Same values as before should pass
+    cc.register_cmap(name, cmap1)
+
+    # Not same values should raise an Error
+    with pytest.raises(
+        ValueError, match=f'A colormap named "{name}" is already registered'
+    ):
+        cc.register_cmap(name, cmap2)


### PR DESCRIPTION
This comes up sometimes when debugging with `panel serve --autoreload` and changing a file in the holoviews/hvplot repo. 

This has only come up for me when debugging, not actual use.

Steps to reproduce:
1) Make a file called with `import colorcet`
2) `panel serve --autoreload` that file
3) Make some changes in `colorcet/__init__.py` and reload the page

``` python-traceback
ValueError: A colormap named "cet_diverging_isoluminant_cjm_75_c23" is already registered.

Traceback (most recent call last):
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.10/site-packages/bokeh/application/handlers/code_runner.py", line 231, in run
    exec(self._code, module.__dict__)
  File "/home/shh/Development/holoviz/development/dev_hvplot/tmp.py", line 1, in <module>
    import colorcet  # noqa
  File "/home/shh/Repos/holoviz/colorcet/colorcet/__init__.py", line 551, in <module>
    m_diverging_isoluminant_cjm_75_c23 = mpl_cm('diverging_isoluminant_cjm_75_c23',diverging_isoluminant_cjm_75_c23)
  File "/home/shh/Repos/holoviz/colorcet/colorcet/__init__.py", line 92, in mpl_cm
    register_cmap("cet_"+name, cmap=cm[name])
  File "/home/shh/Repos/holoviz/colorcet/colorcet/__init__.py", line 70, in register_cmap
    colormaps.register(cmap, name=name)
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.10/site-packages/matplotlib/cm.py", line 136, in register
    raise ValueError(
ValueError: A colormap named "cet_diverging_isoluminant_cjm_75_c23" is already registered.
```