### PR TITLE
docs: Update href to Rogowitz & Treinish 1996

### DIFF
--- a/examples/index.ipynb
+++ b/examples/index.ipynb
@@ -107,7 +107,7 @@
     "You can see all the details about the methods used to create these\n",
     "colormaps in [Peter Kovesi (2015)](https://arxiv.org/pdf/1509.03700v1.pdf) and [Glasbey et al. (2007)](https://strathprints.strath.ac.uk/30312/1/colorpaper_2006.pdf).  Other useful\n",
     "background is available in a research paper from IBM\n",
-    "[(Rogowitz & Treinish 1996)](https://github.com/ResearchComputing/USGS_2015_06_23-25/raw/master/25_June/ColorTheory_References/Why%20Should%20Engineers%20and%20Scientists%20Be%20Worried%20About%20Color.pdf).\n",
+    "[(Rogowitz & Treinish 1996)](https://www.researchgate.net/profile/Ahmed_Elhattab2/post/Please_suggest_some_good_3D_plot_tool_Software_for_surface_plot/attachment/5c05ba35cfe4a7645506948e/AS%3A699894335557644%401543879221725/download/Why+Should+Engineers+and+Scientists+Be+Worried+About+Color_.pdf).\n",
     "\n",
     "The Matplotlib project also has a number of relevant resources, including an excellent \n",
     "[2015 SciPy talk](https://www.youtube.com/watch?v=xAoljeRJ3lU), the\n",


### PR DESCRIPTION
Original href 404s: 
https://github.com/ResearchComputing/USGS_2015_06_23-25/raw/master/25_June/ColorTheory_References/Why%20Should%20Engineers%20and%20Scientists%20Be%20Worried%20About%20Color.pdf .

Updated to
https://www.researchgate.net/profile/Ahmed_Elhattab2/post/Please_suggest_some_good_3D_plot_tool_Software_for_surface_plot/attachment/5c05ba35cfe4a7645506948e/AS%3A699894335557644%401543879221725/download/Why+Should+Engineers+and+Scientists+Be+Worried+About+Color_.pdf ,

which is the top Google hit.