### PR TITLE
CI: skip Python 3.7 on MacOs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,9 @@ jobs:
         # Run on the full set on schedule, workflow_dispatch and push&tags events, otherwise on a subset.
         # python-version: ${{ ( github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || ( github.event_name == 'push' && github.ref_type == 'tag' ) ) && fromJSON('["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]') || fromJSON('["3.7", "3.12"]') }}
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        exclude:
+          - os: 'macos-latest'
+            python-version: "3.7"
     timeout-minutes: 60
     defaults:
       run:


### PR DESCRIPTION
It's been failing for a while on the scheduled runs. Python 3.7 is already tested on Windows and Ubuntu which should be enough, and at some point support for it will be dropped.