### PR TITLE
Update documentation to support matplotlib 3.9

### DIFF
--- a/doc/user_guide/index.ipynb
+++ b/doc/user_guide/index.ipynb
@@ -85,9 +85,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Using `colorcet` via `matplotlib.cm.get_cmap`\n",
+    "#### Using `colorcet` via `matplotlib.colormaps.get_cmap`\n",
     "\n",
-    "The `colorcet` colormaps are all available through `matplotlip.cm.get_cmap` by prepending `cet_`to the colormap name. "
+    "The `colorcet` colormaps are all available through `matplotlip.colormaps.get_cmap` by prepending `cet_`to the colormap name. "
    ]
   },
   {
@@ -96,9 +96,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from matplotlib.cm import get_cmap\n",
+    "import matplotlib\n",
     "\n",
-    "get_cmap(\"cet_fire\")"
+    "matplotlib.colormaps.get_cmap(\"cet_fire\")"
    ]
   },
   {


### PR DESCRIPTION
`matplotlib.cm` is deprecated.
This PR uses `matplotlib.colormaps` instead.