### PR TITLE
Migrate colorcet to using pixi for development

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,7 +71,7 @@ jobs:
       - name: Set environment variables
         run: |
           echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-          echo "CONDA_FILE=$(ls dist/*.conda)" >> $GITHUB_ENV
+          echo "CONDA_FILE=$(ls dist/*.tar.bz2)" >> $GITHUB_ENV
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
         if: always()
         with:
           name: conda
-          path: dist/*.conda
+          path: dist/*.tar.bz2
           if-no-files-found: error
 
   conda-publish:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,4 @@
 name: packages
-
 on:
   push:
     tags:
@@ -14,12 +13,23 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
+  PACKAGE: "colorcet"
 
 defaults:
   run:
     shell: bash -e {0}
 
 jobs:
+  waiting_room:
+    name: Waiting Room
+    runs-on: ubuntu-latest
+    needs: [conda_build, pip_install]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    environment:
+      name: publish
+    steps:
+      - run: echo "All builds have finished, have been approved, and ready to publish"
+
   pixi_lock:
     name: Pixi lock
     runs-on: ubuntu-latest
@@ -38,23 +48,50 @@ jobs:
           install: false
       - name: conda build
         run: pixi run -e build build-conda
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: conda
+          path: dist/*.conda
+          if-no-files-found: error
+
+  conda-publish:
+    name: Publish Conda
+    runs-on: ubuntu-latest
+    needs: [conda_build, waiting_room]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    defaults:
+      run:
+        shell: bash -el {0}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: conda
+          path: dist/
       - name: Set environment variables
         run: |
           echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-          echo "CONDA_FILE=$(ls dist/*.tar.bz2)" >> $GITHUB_ENV
+          echo "CONDA_FILE=$(ls dist/*.conda)" >> $GITHUB_ENV
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniconda-version: "latest"
+          channels: "conda-forge"
+      - name: conda setup
+        run: |
+          conda install -y anaconda-client
       - name: conda dev upload
         if: contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')
-        run: pixi run -e build publish-conda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev $CONDA_FILE
+        run: |
+          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev $CONDA_FILE
       - name: conda main upload
         if: (!(contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')))
-        run: pixi run -e build publish-conda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $CONDA_FILE
+        run: |
+          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $CONDA_FILE
 
   pip_build:
     name: Build PyPI
     needs: [pixi_lock]
     runs-on: "ubuntu-latest"
-    permissions:
-      id-token: write
     steps:
       - uses: holoviz-dev/holoviz_tasks/pixi_install@v0
         with:
@@ -63,6 +100,45 @@ jobs:
           install: false
       - name: Build package
         run: pixi run -e build build-pip
-      - name: Publish to PyPI
-        if: github.event_name == 'push'
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: pip
+          path: dist/
+          if-no-files-found: error
+
+  pip_install:
+    name: Install PyPI
+    runs-on: "ubuntu-latest"
+    needs: [pip_build]
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: pip
+          path: dist/
+      - name: Install package
+        run: python -m pip install dist/*.whl
+      - name: Import package
+        run: python -c "import $PACKAGE; print($PACKAGE._version.__version__)"
+
+  pip_publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [pip_build, waiting_room]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    permissions:
+      id-token: write
+    steps:
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          name: pip
+          path: dist/
+      - name: Publish to PyPi
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: ${{ secrets.PPU }}
+          password: ${{ secrets.PPP }}
+          packages-dir: dist/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,64 +12,57 @@ on:
   schedule:
     - cron: '0 9 * * SUN'
 
+env:
+  PYTHON_VERSION: "3.11"
+
+defaults:
+  run:
+    shell: bash -e {0}
+
 jobs:
+  pixi_lock:
+    name: Pixi lock
+    runs-on: ubuntu-latest
+    steps:
+      - uses: holoviz-dev/holoviz_tasks/pixi_lock@v0
+
   conda_build:
-    name: Build Conda Packages
-    runs-on: 'ubuntu-latest'
-    defaults:
-      run:
-        shell: bash -l {0}
+    name: Build Conda
+    needs: [pixi_lock]
+    runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v4
-      - name: Fetch unshallow
-        run: git fetch --prune --tags --unshallow -f
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: holoviz-dev/holoviz_tasks/pixi_install@v0
         with:
-          miniconda-version: "latest"
-          python-version: "3.11"
-          auto-update-conda: true
-      - name: Set output
-        id: vars
-        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-      - name: conda setup
-        run: |
-          conda install anaconda-client conda-build setuptools_scm
+          environments: "build"
+          download-data: false
+          install: false
       - name: conda build
+        run: pixi run -e build build-conda
+      - name: Set environment variables
         run: |
-          VERSION=`python -m setuptools_scm` conda build conda.recipe/
+          echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo "CONDA_FILE=$(ls dist/*.tar.bz2)" >> $GITHUB_ENV
       - name: conda dev upload
-        if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
-        run: |
-          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev $(VERSION=`python -m setuptools_scm` conda build --output conda.recipe)
+        if: contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')
+        run: pixi run -e build publish-conda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev $CONDA_FILE
       - name: conda main upload
-        if: (github.event_name == 'push' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
-        run: |
-          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $(VERSION=`python -m setuptools_scm` conda build --output conda.recipe)
+        if: (!(contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')))
+        run: pixi run -e build publish-conda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $CONDA_FILE
+
   pip_build:
-    name: Build PyPI Packages
-    runs-on: 'ubuntu-latest'
-    defaults:
-      run:
-        shell: bash -l {0}
+    name: Build PyPI
+    needs: [pixi_lock]
+    runs-on: "ubuntu-latest"
+    permissions:
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - name: Fetch unshallow
-        run: git fetch --prune --tags --unshallow -f
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: holoviz-dev/holoviz_tasks/pixi_install@v0
         with:
-          python-version: "3.11"
-      - name: env setup
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install build
-      - name: pip build
-        run: |
-          python -m build
-      - name: Publish package to PyPI
+          environments: "build"
+          download-data: false
+          install: false
+      - name: Build package
+        run: pixi run -e build build-pip
+      - name: Publish to PyPI
         if: github.event_name == 'push'
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: ${{ secrets.PPU }}
-          password: ${{ secrets.PPP }}
-          packages-dir: dist/

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,6 +1,4 @@
-
 name: docs
-
 on:
   push:
     tags:
@@ -22,38 +20,40 @@ on:
   schedule:
     - cron: '0 9 * * SUN'
 
+defaults:
+  run:
+    shell: bash -e {0}
+
+env:
+  PYTHON_VERSION: "3.11"
+
 jobs:
-  build_docs:
-    name: Documentation
+  pixi_lock:
+    name: Pixi lock
+    runs-on: ubuntu-latest
+    steps:
+      - uses: holoviz-dev/holoviz_tasks/pixi_lock@v0
+
+  docs_build:
+    name: Build Documentation
     runs-on: 'ubuntu-latest'
     timeout-minutes: 120
-    defaults:
-      run:
-        shell: bash -l {0}
     env:
-      MPLBACKEND: "Agg"
       DISPLAY: ":99.0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: holoviz-dev/holoviz_tasks/pixi_install@v0
         with:
-          fetch-depth: "100"
-      - name: Fetch
-        run: git fetch --prune --tags -f
+          environments: docs
+      - name: Build documentation
+        run: pixi run -e docs docs-build
       - name: Set output
         id: vars
-        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - name: install
-        run: pip install ."[doc, examples]"
-      - name: build docs
-        run: sphinx-build -b html doc builtdocs
-      - name: git status
         run: |
-          git status
-          git diff
+          echo "Deploying from ref ${GITHUB_REF#refs/*/}"
+          echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+      - name: report failure
+        if: failure()
+        run: cat /tmp/sphinx-*.log | tail -n 100
       - name: Deploy dev
         uses: peaceiris/actions-gh-pages@v3
         if: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        description: 'Site to build and deploy'
+        description: 'Site to build and deploy, or dry-run'
         type: choice
         options:
         - dev
@@ -26,6 +26,7 @@ defaults:
 
 env:
   PYTHON_VERSION: "3.11"
+  MPLBACKEND: "Agg"
 
 jobs:
   pixi_lock:
@@ -36,16 +37,26 @@ jobs:
 
   docs_build:
     name: Build Documentation
+    needs: [pixi_lock]
     runs-on: 'ubuntu-latest'
     timeout-minutes: 120
+    outputs:
+      tag: ${{ steps.vars.outputs.tag }}
     env:
       DISPLAY: ":99.0"
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: holoviz-dev/holoviz_tasks/pixi_install@v0
         with:
           environments: docs
       - name: Build documentation
         run: pixi run -e docs docs-build
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: docs
+          if-no-files-found: error
+          path: builtdocs
       - name: Set output
         id: vars
         run: |
@@ -54,6 +65,24 @@ jobs:
       - name: report failure
         if: failure()
         run: cat /tmp/sphinx-*.log | tail -n 100
+
+  docs_publish:
+    name: Publish Documentation
+    runs-on: "ubuntu-latest"
+    needs: [docs_build]
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: docs
+          path: builtdocs/
+      - name: Set output
+        id: vars
+        run: echo "tag=${{ needs.docs_build.outputs.tag }}" >> $GITHUB_OUTPUT
       - name: Deploy dev
         uses: peaceiris/actions-gh-pages@v3
         if: |

--- a/.github/workflows/nightly_lock.yaml
+++ b/.github/workflows/nightly_lock.yaml
@@ -15,10 +15,3 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: holoviz-dev/holoviz_tasks/pixi_lock@v0
-      - name: Upload lock-file to S3
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: "eu-west-1"
-        run: |
-          zip $(date +%Y-%m-%d).zip pixi.lock pixi.toml

--- a/.github/workflows/nightly_lock.yaml
+++ b/.github/workflows/nightly_lock.yaml
@@ -1,0 +1,25 @@
+name: nightly_lock
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+env:
+  PACKAGE: "colorcet"
+
+jobs:
+  pixi_lock:
+    if: ${{ !github.event.repository.fork }}
+    name: Pixi lock
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: holoviz-dev/holoviz_tasks/pixi_lock@v0
+      - name: Upload lock-file to S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: "eu-west-1"
+        run: |
+          zip $(date +%Y-%m-%d).zip pixi.lock pixi.toml
+          aws s3 cp ./$(date +%Y-%m-%d).zip s3://assets.holoviz.org/lock/$PACKAGE/

--- a/.github/workflows/nightly_lock.yaml
+++ b/.github/workflows/nightly_lock.yaml
@@ -22,4 +22,3 @@ jobs:
           AWS_DEFAULT_REGION: "eu-west-1"
         run: |
           zip $(date +%Y-%m-%d).zip pixi.lock pixi.toml
-          aws s3 cp ./$(date +%Y-%m-%d).zip s3://assets.holoviz.org/lock/$PACKAGE/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -127,9 +127,6 @@ jobs:
       - uses: holoviz-dev/holoviz_tasks/pixi_install@v0
         with:
           environments: ${{ matrix.environment }}
-      - name: Check packages latest version
-        run: |
-          pixi run -e ${{ matrix.environment }} check-latest-packages bokeh panel param datashader
       - name: Test Unit
         run: |
           pixi run -e ${{ matrix.environment }} test-unit $COV
@@ -155,9 +152,6 @@ jobs:
       - uses: holoviz-dev/holoviz_tasks/pixi_install@v0
         with:
           environments: ${{ matrix.environment }}
-      - name: Check packages latest version
-        run: |
-          pixi run -e ${{ matrix.environment }} check-latest-packages numpy pandas bokeh panel param
       - name: Test Unit
         run: |
           pixi run -e ${{ matrix.environment }} test-unit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,6 @@ defaults:
     shell: bash -e {0}
 
 env:
-  MPLBACKEND: "Agg"
   DISPLAY: ":99.0"
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   COV: "--cov=./colorcet --cov-report=xml"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,4 @@
 name: tests
-
 on:
   push:
     branches:
@@ -14,6 +13,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash -e {0}
 
 jobs:
   pre_commit:
@@ -36,9 +39,6 @@ jobs:
           - os: 'macos-latest'
             python-version: "3.7"
     timeout-minutes: 60
-    defaults:
-      run:
-        shell: bash -e {0}
     env:
       MPLBACKEND: "Agg"
       DISPLAY: ":99.0"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,6 +52,7 @@ jobs:
     outputs:
       code_change: ${{ steps.filter.outputs.code }}
       matrix: ${{ env.MATRIX }}
+      matrix_option: ${{ env.MATRIX_OPTION }}
     steps:
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request'
@@ -85,7 +86,7 @@ jobs:
               "environment": ["test-39", "test-312"],
               "exclude": [
                 {
-                "environment": "test-37",
+                "environment": "test-39",
                 "os": "macos-latest"
                 }
               ]
@@ -99,7 +100,7 @@ jobs:
               "environment": ["test-39", "test-310", "test-311", "test-312"],
               "exclude": [
                 {
-                "environment": "test-37",
+                "environment": "test-39",
                 "os": "macos-latest"
                 }
               ]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -105,7 +105,7 @@ jobs:
                 }
               ]
           }')
-          echo "MATRIX=$MATRIX" >> $GITHUB_ENV
+          echo "MATRIX=$MATRIX" >> $GITHUB_OUTPUT
 
   pixi_lock:
       name: Pixi lock

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,6 @@ jobs:
     outputs:
       code_change: ${{ steps.filter.outputs.code }}
       matrix: ${{ env.MATRIX }}
-      matrix_option: ${{ env.MATRIX_OPTION }}
     steps:
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request'
@@ -91,7 +90,7 @@ jobs:
                 }
               ]
           }')
-          echo "MATRIX=$MATRIX" >> $GITHUB_OUTPUT
+          echo "MATRIX=$MATRIX" >> $GITHUB_ENV
       - name: Set test matrix with 'full' option
         if: env.MATRIX_OPTION == 'full'
         run: |
@@ -105,7 +104,7 @@ jobs:
                 }
               ]
           }')
-          echo "MATRIX=$MATRIX" >> $GITHUB_OUTPUT
+          echo "MATRIX=$MATRIX" >> $GITHUB_ENV
 
   pixi_lock:
       name: Pixi lock

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,19 @@ on:
     branches:
       - "*"
   workflow_dispatch:
+    inputs:
+      target:
+        description: "How much of the test suite to run"
+        type: choice
+        default: default
+        options:
+          - default
+          - full
+      cache:
+        description: "Use cache"
+        type: boolean
+        default: true
+
   schedule:
     - cron: "0 9 * * SUN"
 
@@ -18,48 +31,143 @@ defaults:
   run:
     shell: bash -e {0}
 
+env:
+  MPLBACKEND: "Agg"
+  DISPLAY: ":99.0"
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  COV: "--cov=./colorcet --cov-report=xml"
+
 jobs:
   pre_commit:
     name: Run pre-commit
     runs-on: "ubuntu-latest"
     steps:
       - uses: holoviz-dev/holoviz_tasks/pre-commit@v0
-  test_suite:
-    name: Pytest on ${{ matrix.python-version }}, ${{ matrix.os }}
-    needs: [pre_commit]
+
+  setup:
+    name: Setup workflow
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      code_change: ${{ steps.filter.outputs.code }}
+      matrix: ${{ env.MATRIX }}
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name != 'pull_request'
+      - name: Check for code changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'colorcet/**'
+              - 'pixi.toml'
+              - 'pyproject.toml'
+              - '.github/workflows/test.yaml'
+      - name: Set matrix option
+        run: |
+          if [[ '${{ github.event_name }}' == 'workflow_dispatch' ]]; then
+            OPTION=${{ github.event.inputs.target }}
+          elif [[ '${{ github.event_name }}' == 'schedule' ]]; then
+            OPTION="full"
+          elif [[ '${{ github.event_name }}' == 'push' && '${{ github.ref_type }}' == 'tag' ]]; then
+            OPTION="full"
+          else
+            OPTION="default"
+          fi
+          echo "MATRIX_OPTION=$OPTION" >> $GITHUB_ENV
+      - name: Set test matrix with 'default' option
+        if: env.MATRIX_OPTION == 'default'
+        run: |
+          MATRIX=$(jq -nsc '{
+              "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
+              "environment": ["test-39", "test-312"],
+              "exclude": [
+                {
+                "environment": "test-37",
+                "os": "macos-latest"
+                }
+              ]
+          }')
+          echo "MATRIX=$MATRIX" >> $GITHUB_OUTPUT
+      - name: Set test matrix with 'full' option
+        if: env.MATRIX_OPTION == 'full'
+        run: |
+          MATRIX=$(jq -nsc '{
+              "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
+              "environment": ["test-39", "test-310", "test-311", "test-312"],
+              "exclude": [
+                {
+                "environment": "test-37",
+                "os": "macos-latest"
+                }
+              ]
+          }')
+          echo "MATRIX=$MATRIX" >> $GITHUB_ENV
+
+  pixi_lock:
+      name: Pixi lock
+      runs-on: ubuntu-latest
+      steps:
+        - uses: holoviz-dev/holoviz_tasks/pixi_lock@v0
+          with:
+            cache: ${{ github.event.inputs.cache == 'true' || github.event.inputs.cache == '' }}
+
+  unit_test_suite:
+    name: unit:${{ matrix.environment }}:${{ matrix.os }}
+    needs: [pre_commit, setup, pixi_lock]
     runs-on: ${{ matrix.os }}
+    if: needs.setup.outputs.code_change == 'true'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+    timeout-minutes: 60
+    steps:
+      - uses: holoviz-dev/holoviz_tasks/pixi_install@v0
+        with:
+          environments: ${{ matrix.environment }}
+      - name: Check packages latest version
+        run: |
+          pixi run -e ${{ matrix.environment }} check-latest-packages bokeh panel param datashader
+      - name: Test Unit
+        run: |
+          pixi run -e ${{ matrix.environment }} test-unit $COV
+      - name: Test Examples
+        run: |
+          pixi run -e ${{ matrix.environment }} test-example
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  core_test_suite:
+    name: core:${{ matrix.environment }}:${{ matrix.os }}
+    needs: [pre_commit, setup, pixi_lock]
+    runs-on: ${{ matrix.os }}
+    if: needs.setup.outputs.code_change == 'true'
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        # Run on the full set on schedule, workflow_dispatch and push&tags events, otherwise on a subset.
-        # python-version: ${{ ( github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || ( github.event_name == 'push' && github.ref_type == 'tag' ) ) && fromJSON('["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]') || fromJSON('["3.7", "3.13"]') }}
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        exclude:
-          - os: 'macos-latest'
-            python-version: "3.7"
+        os: ["ubuntu-latest"]
+        environment: ["test-core"]
     timeout-minutes: 60
-    env:
-      MPLBACKEND: "Agg"
-      DISPLAY: ":99.0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: holoviz-dev/holoviz_tasks/pixi_install@v0
         with:
-          fetch-depth: "100"
-      - name: Fetch
-        run: git fetch --prune --tags -f
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          enable-cache: false
-      - name: install
-        run: uv pip install -e ."[tests,tests_examples,tests_extra]"
-      - name: unit tests
-        run: uv run python -m pytest colorcet --cov=colorcet --cov-append --cov-report xml
-      - name: examples tests
-        run: uv run python -m pytest doc --nbval-lax -p no:python
-      - name: doit test_unit_extra
-        run: uv run python -m pytest colorcet --mpl
-      - uses: codecov/codecov-action@v4
-        if: github.event_name == 'push'
+          environments: ${{ matrix.environment }}
+      - name: Check packages latest version
+        run: |
+          pixi run -e ${{ matrix.environment }} check-latest-packages numpy pandas bokeh panel param
+      - name: Test Unit
+        run: |
+          pixi run -e ${{ matrix.environment }} test-unit
+
+  result_test_suite:
+    name: result:test
+    needs: [unit_test_suite, core_test_suite]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: echo job failed && exit 1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,13 +82,6 @@ jobs:
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
               "environment": ["test-39", "test-312"],
-              "exclude": [
-                {
-                "environment": "test-39",
-                "os": "macos-latest"
-                }
-              ]
-          }')
           echo "MATRIX=$MATRIX" >> $GITHUB_ENV
       - name: Set test matrix with 'full' option
         if: env.MATRIX_OPTION == 'full'
@@ -96,13 +89,6 @@ jobs:
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
               "environment": ["test-39", "test-310", "test-311", "test-312"],
-              "exclude": [
-                {
-                "environment": "test-39",
-                "os": "macos-latest"
-                }
-              ]
-          }')
           echo "MATRIX=$MATRIX" >> $GITHUB_ENV
 
   pixi_lock:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,6 +82,7 @@ jobs:
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
               "environment": ["test-39", "test-312"],
+            }')
           echo "MATRIX=$MATRIX" >> $GITHUB_ENV
       - name: Set test matrix with 'full' option
         if: env.MATRIX_OPTION == 'full'
@@ -89,6 +90,7 @@ jobs:
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
               "environment": ["test-39", "test-310", "test-311", "test-312"],
+            }')
           echo "MATRIX=$MATRIX" >> $GITHUB_ENV
 
   pixi_lock:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,7 +89,7 @@ jobs:
         run: |
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
-              "environment": ["test-39", "test-310", "test-311", "test-312"],
+              "environment": ["test-38", "test-39", "test-310", "test-311", "test-312"],
             }')
           echo "MATRIX=$MATRIX" >> $GITHUB_ENV
 

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ assets/CET_updates.py
 
 # setuptools_scm
 colorcet/_version.py
+
+# pixi
+.pixi
+pixi.lock

--- a/doc/developer_guide.md
+++ b/doc/developer_guide.md
@@ -1,0 +1,235 @@
+# Setting up a development environment
+
+This guide describes how to install and configure the development environment for contributing to the colorcet repository.
+
+If you have any problems with the steps here, please reach out in the `dev` channel on [Discord](https://discord.gg/rb6gPXbdAr) or on [Discourse](https://discourse.holoviz.org/).
+
+## TL;DR
+
+0. Open an [issue on Github](https://github.com/holoviz/colorcet/issues) if needed
+1. Fork and clone [colorcet's Github repository](https://github.com/holoviz/colorcet)
+2. Install [`pixi`](https://pixi.sh)
+3. Run `pixi run install-dev` to create your development environment
+4. Make some changes and run:
+  - `pixi run test-unit` if you updated the source code to run the unit tests
+  - `pixi run test-example` if you updated the notebooks to run them
+  - `pixi run docs-build` if you need to build the website locally
+5. Open a Pull Request
+
+## Preliminaries
+
+### Basic understanding of how to contribute to Open Source
+
+If this is your first open-source contribution, please study one
+or more of the below resources.
+
+- [How to Get Started with Contributing to Open Source | Video](https://youtu.be/RGd5cOXpCQw)
+- [Contributing to Open-Source Projects as a New Python Developer | Video](https://youtu.be/jTTf4oLkvaM)
+- [How to Contribute to an Open Source Python Project | Blog post](https://www.educative.io/blog/contribue-open-source-python-project)
+
+### Git
+
+The colorcet source code is stored in a [Git](https://git-scm.com) source control repository. The first step to working on colorcet is to install Git onto your system. There are different ways to do this, depending on whether you use Windows, Mac, or Linux.
+
+To install Git on any platform, refer to the [Installing Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) section of the [Pro Git Book](https://git-scm.com/book/en/v2).
+
+To contribute to colorcet, you will also need [Github account](https://github.com/join) and knowledge of the [_fork and pull request workflow_](https://docs.github.com/en/get-started/quickstart/contributing-to-projects).
+
+### Pixi
+
+Developing all aspects of colorcet requires a wide range of packages in different environments, but for new contributors the `default` environment will be more than enough.
+
+To make this more manageable, Pixi manages the developer experience. To install Pixi, follow [this guide](https://pixi.sh/latest/#installation).
+
+#### Glossary
+
+- *Tasks*: A task is what can be run with `pixi run <task-name>`. Tasks can be anything from installing packages to running tests.
+- *Environments*: An environment is a set of packages installed in a virtual environment. Each environment has a name; you can run tasks in a specific environment with the `-e` flag. For example, `pixi run -e test-core test-unit` will run the `test-unit` task in the `test-core` environment.
+- *Lock-file*: A lock-file is a file that contains all the information about the environments.
+
+For more information, see the [Pixi documentation](https://pixi.sh/latest/).
+
+:::{admonition} Note
+:class: info
+
+The first time you run `pixi`, it will create a `.pixi` directory in the source directory. This directory will contain all the files needed for the virtual environments. The `.pixi` directory can be large, so it is advised not to put the source directory into a cloud-synced directory.
+
+:::
+
+## Installing the Project
+
+### Cloning the Project
+
+The source code for the colorcet project is hosted on [GitHub](https://github.com/holoviz/colorcet). The first thing you need to do is clone the repository.
+
+1. Go to [github.com/holoviz/colorcet](https://github.com/holoviz/colorcet)
+2. [Fork the repository](https://docs.github.com/en/get-started/quickstart/contributing-to-projects#forking-a-repository)
+3. Run in your terminal: `git clone https://github.com/<Your Username Here>/colorcet`
+
+The instructions for cloning above created a `colorcet` directory at your file system location.
+This `colorcet` directory is the _source checkout_ for the remainder of this document, and your current working directory is this directory.
+
+## Start developing
+
+To start developing, run the following command:
+
+```bash
+pixi run install-dev
+```
+
+This will create an environment called `default` (in `.pixi/envs`), install colorcet in [editable mode](https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs), and install `pre-commit`:
+
+
+:::{admonition} Note
+:class: info
+
+The first time you run it, it will create a `pixi.lock` file with information for all available environments.
+This command will take a minute or so to run.
+:::
+
+All available tasks can be found by running `pixi task list`, the following sections will give a brief introduction to the most common tasks.
+
+### Syncing Git tags with upstream repository
+
+If you are working from a forked repository of colorcet, you will need to sync the tags with the upstream repository.
+This is needed because the colorcet version number depends on [`git tags`](https://git-scm.com/book/en/v2/Git-Basics-Tagging).
+Syncing the git tags can be done with:
+
+```bash
+pixi run sync-git-tags
+```
+
+## Developer Environment
+
+The `default` environment is meant to provide all the tools needed to develop colorcet.
+
+This environment is created by running `pixi run install-dev`. Run `pixi shell` to activate it; this is equivalent to `source venv/bin/activate` in a Python virtual environment or `conda activate` in a conda environment.
+
+If you need to run a command directly instead of via `pixi`, activate the environment and run the command (e.g. `pixi shell` and `pytest colorcet/tests/<somefile.py>`).
+
+### VS Code
+
+This environment can also be selected in your IDE. In VS Code, this can be done by running the command `Python: Select Interpreter` and choosing `{'default': Pixi}`.
+
+<p style="text-align: center">
+  <img
+    src="https://assets.holoviews.org/static/dev_guide/001.png"
+    alt="001"
+    style="width: 45%; display: inline-block"
+  />
+  <img
+    src="https://assets.holoviews.org/static/dev_guide/002.png"
+    alt="002"
+    style="width: 45%; display: inline-block"
+  />
+</p>
+
+To confirm you are using this dev environment, check the bottom right corner:
+
+![003](https://assets.holoviews.org/static/dev_guide/003.png)
+
+### Jupyter Lab
+
+You can launch Jupyter lab with the `default` environment with `pixi run lab`. This can be advantageous when you need to edit the documentation or debug an example notebook.
+
+## Linting
+
+colorcet uses [`pre-commit`](https://pre-commit.com/) to lint and format the source code. `pre-commit` is installed automatically when running `pixi run install-dev`; it can also be installed with `pixi run lint-install`.
+`pre-commit` runs all the linters when a commit is made locally. Linting can be forced to run for all the files with:
+
+```bash
+pixi run lint
+```
+
+:::{admonition} Note
+:class: info
+
+Alternatively, if you have `pre-commit` installed elsewhere you can run:
+
+```bash
+pre-commit install  # To install
+pre-commit run --all-files  # To run on all files
+```
+
+:::
+
+## Testing
+
+To help keep colorcet maintainable, all Pull Requests (PR) with code changes should typically be accompanied by relevant tests. While exceptions may be made for specific circumstances, the default assumption should be that a Pull Request without tests will not be merged.
+
+There are three types of tasks and five environments related to tests.
+
+### Unit tests
+
+Unit tests are usually small tests executed with [pytest](https://docs.pytest.org). They can be found in `colorcet/tests/`.
+Unit tests can be run with the `test-unit` task:
+
+```bash
+pixi run test-unit
+```
+
+:::{admonition} Advanced usage
+:class: tip
+
+The task is available in the following environments: `test-39`, `test-310`, `test-311`, `test-312`, and `test-core`. Where the first ones have the same environments except for different Python versions, and `test-core` only has a core set of dependencies.
+
+You can run the task in a specific environment with the `-e` flag. For example, to run the `test-unit` task in the `test-39` environment, you can run:
+
+```bash
+pixi run -e test-39 test-unit
+```
+
+:::
+
+:::{admonition} Advanced usage
+:class: tip
+
+Currently, an editable install needs to be run in each environment. So, if you want to install in the `test-core` environment, you can add `--environment` / `-e` to the command:
+
+```bash
+pixi run -e test-core install
+```
+
+:::
+
+### Example tests
+
+colorcet's documentation consists mainly of Jupyter Notebooks. The example tests execute all the notebooks and fail if an error is raised. Example tests are possible thanks to [nbval](https://nbval.readthedocs.io/) and can be found in the `doc/` folder.
+Example tests can be run with the following command:
+
+```bash
+pixi run test-example
+```
+
+## Documentation
+
+The documentation can be built with the command:
+
+```bash
+pixi run docs-build
+```
+
+A development version of colorcet can be found [here](https://holoviz-dev.github.io/colorcet/). You can ask a maintainer if they want to make a dev release for your PR, but there is no guarantee they will say yes.
+
+## Build
+
+colorcet has two build tasks to build a Python (for pypi.org) and a Conda package (for anaconda.org).
+
+```bash
+pixi run build-pip
+pixi run build-conda
+```
+
+## Continuous Integration
+
+Every push to the `main` branch or any PR branch on GitHub automatically triggers a test build with [GitHub Actions](https://github.com/features/actions).
+
+You can see the list of all current and previous builds at [this URL](https://github.com/holoviz/colorcet/actions)
+
+### Etiquette
+
+GitHub Actions provides free build workers for open-source projects. A few considerations will help you be considerate of others needing these limited resources:
+
+- Run the tests locally before opening or pushing to an opened PR.
+
+- Group commits to meaningful chunks of work before pushing to GitHub (i.e., don't push on every commit).

--- a/doc/developer_guide.md
+++ b/doc/developer_guide.md
@@ -4,18 +4,17 @@ This guide describes how to install and configure the development environment fo
 
 If you have any problems with the steps here, please reach out in the `dev` channel on [Discord](https://discord.gg/rb6gPXbdAr) or on [Discourse](https://discourse.holoviz.org/).
 
-## TL;DR
+## Quick Overview
 
 0. Open an [issue on Github](https://github.com/holoviz/colorcet/issues) if needed
 1. Fork and clone [colorcet's Github repository](https://github.com/holoviz/colorcet)
 2. Install [`pixi`](https://pixi.sh)
 3. Run `pixi run setup-dev` to create your development environment
-4. Run `pixi shell` to activate the created environment
-5. Make some changes and run:
+4. Make some changes and run:
   - `pixi run test-unit` if you updated the source code to run the unit tests
   - `pixi run test-example` if you updated the notebooks to run them
   - `pixi run docs-build` if you need to build the website locally
-6. Open a Pull Request
+5. Open a Pull Request
 
 ## Preliminaries
 

--- a/doc/developer_guide.md
+++ b/doc/developer_guide.md
@@ -10,11 +10,12 @@ If you have any problems with the steps here, please reach out in the `dev` chan
 1. Fork and clone [colorcet's Github repository](https://github.com/holoviz/colorcet)
 2. Install [`pixi`](https://pixi.sh)
 3. Run `pixi run install-dev` to create your development environment
-4. Make some changes and run:
+4. Run `pixi shell` to activate the created environment
+5. Make some changes and run:
   - `pixi run test-unit` if you updated the source code to run the unit tests
   - `pixi run test-example` if you updated the notebooks to run them
   - `pixi run docs-build` if you need to build the website locally
-5. Open a Pull Request
+6. Open a Pull Request
 
 ## Preliminaries
 

--- a/doc/developer_guide.md
+++ b/doc/developer_guide.md
@@ -9,7 +9,7 @@ If you have any problems with the steps here, please reach out in the `dev` chan
 0. Open an [issue on Github](https://github.com/holoviz/colorcet/issues) if needed
 1. Fork and clone [colorcet's Github repository](https://github.com/holoviz/colorcet)
 2. Install [`pixi`](https://pixi.sh)
-3. Run `pixi run install-dev` to create your development environment
+3. Run `pixi run install` to create your development environment
 4. Run `pixi shell` to activate the created environment
 5. Make some changes and run:
   - `pixi run test-unit` if you updated the source code to run the unit tests

--- a/doc/developer_guide.md
+++ b/doc/developer_guide.md
@@ -9,7 +9,7 @@ If you have any problems with the steps here, please reach out in the `dev` chan
 0. Open an [issue on Github](https://github.com/holoviz/colorcet/issues) if needed
 1. Fork and clone [colorcet's Github repository](https://github.com/holoviz/colorcet)
 2. Install [`pixi`](https://pixi.sh)
-3. Run `pixi run install` to create your development environment
+3. Run `pixi run setup-dev` to create your development environment
 4. Run `pixi shell` to activate the created environment
 5. Make some changes and run:
   - `pixi run test-unit` if you updated the source code to run the unit tests
@@ -75,7 +75,7 @@ This `colorcet` directory is the _source checkout_ for the remainder of this doc
 To start developing, run the following command:
 
 ```bash
-pixi run install-dev
+pixi run setup-dev
 ```
 
 This will create an environment called `default` (in `.pixi/envs`), install colorcet in [editable mode](https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs), and install `pre-commit`:
@@ -86,6 +86,7 @@ This will create an environment called `default` (in `.pixi/envs`), install colo
 
 The first time you run it, it will create a `pixi.lock` file with information for all available environments.
 This command will take a minute or so to run.
+
 :::
 
 All available tasks can be found by running `pixi task list`, the following sections will give a brief introduction to the most common tasks.
@@ -104,7 +105,7 @@ pixi run sync-git-tags
 
 The `default` environment is meant to provide all the tools needed to develop colorcet.
 
-This environment is created by running `pixi run install-dev`. Run `pixi shell` to activate it; this is equivalent to `source venv/bin/activate` in a Python virtual environment or `conda activate` in a conda environment.
+This environment is created by running `pixi run setup-dev`. Run `pixi shell` to activate it; this is equivalent to `source venv/bin/activate` in a Python virtual environment or `conda activate` in a conda environment.
 
 If you need to run a command directly instead of via `pixi`, activate the environment and run the command (e.g. `pixi shell` and `pytest colorcet/tests/<somefile.py>`).
 
@@ -135,7 +136,7 @@ You can launch Jupyter lab with the `default` environment with `pixi run lab`. T
 
 ## Linting
 
-colorcet uses [`pre-commit`](https://pre-commit.com/) to lint and format the source code. `pre-commit` is installed automatically when running `pixi run install-dev`; it can also be installed with `pixi run lint-install`.
+Colorcet uses [`pre-commit`](https://pre-commit.com/) to lint and format the source code. `pre-commit` is installed automatically when running `pixi run setup-dev`; it can also be installed with `pixi run lint-install`.
 `pre-commit` runs all the linters when a commit is made locally. Linting can be forced to run for all the files with:
 
 ```bash

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -53,24 +53,3 @@ regular colormap.
 If you have any questions, please refer to the `User Guide <../user_guide/index>`_
 and if that doesn't help, feel free to post an issue on GitHub, question on stackoverflow,
 or discuss on Gitter.
-
-Developer Instructions
-----------------------
-
-1. Install Python and pip.
-
-2. Clone the colorcet git repository if you do not already have it::
-
-    git clone git://github.com/pyviz/colorcet.git
-
-3. Set up a new environment with all the required dependencies::
-
-    cd colorcet
-    # <your command to create a new environment>
-    pip install -e .[all]
-
-4. Run the unit tests / run the examples tests / build the docs ::
-
-    pytest colorcet
-    pytest doc --nbval-lax -p no:python
-    sphinx-build -b html doc builtdocs

--- a/doc/index.ipynb
+++ b/doc/index.ipynb
@@ -133,6 +133,7 @@
     "Introduction <self>\n",
     "Getting Started <getting_started/index>\n",
     "User Guide <user_guide/index>\n",
+    "Developer Guide <developer_guide>\n",
     "About <about>\n",
     "```"
    ]

--- a/pixi.toml
+++ b/pixi.toml
@@ -140,7 +140,6 @@ _docs-install = 'python -m pip install --no-deps --disable-pip-version-check -e 
 # in the default environment
 docs-build = { depends-on = ["_docs-install", "docs-build-sphinx"] }
 
-
 # ================== BUILD ====================
 
 [feature.build.dependencies]

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,19 +1,14 @@
 [project]
 name = "colorcet"
-channels = ["pyviz/label/dev",  "conda-forge"]
+channels = ["pyviz/label/dev", "conda-forge"]
 platforms = ["linux-64", "osx-arm64", "osx-64", "win-64"]
 
+[activation.env]
+MPLBACKEND = "Agg"
+PYTHONIOENCODING = "utf-8"
+
 [environments]
-default = [
-    "py312",
-    "required",
-    "test-core",
-    "test",
-    "example",
-    "test-example",
-    "lint",
-    "dev",
-]
+default = ["py312", "required", "test-core", "test", "example", "test-example", "lint", "dev"]
 
 [environments.test-39]
 features = ["py39", "required", "test-core", "test", "example", "test-example"]
@@ -50,21 +45,11 @@ no-default-feature = true
 [feature.required.dependencies]
 nomkl = "*"
 pip = "*"
-# Required
-bokeh = ">=3.1"
-holoviews = ">=1.19.0"
-numpy = ">=1.21"
-packaging = "*"
-panel = ">=1.0"
-param = ">=1.12.0,<3.0"
 
 [feature.required.tasks]
 install = 'python -m pip install --no-deps --disable-pip-version-check -e .'
 setup-dev = { depends-on = ["install", "lint-install"] }
 sync-git-tags = 'python scripts/sync_git_tags.py colorcet'
-
-[feature.required.activation.env]
-PYTHONIOENCODING = "utf-8"
 
 [feature.py39.dependencies]
 python = "3.9.*"
@@ -101,30 +86,33 @@ lab = 'jupyter lab'
 
 # Dependencies required to run the notebooks
 [feature.example.dependencies]
-datashader = ">=0.6.5"
-nbsite = ">=0.8.4"
+bokeh = "*"
+holoviews = "*"
+matplotlib = "*"
+numpy = "*"
 
 # =================== TESTS ===================
 
 [feature.test-core.dependencies]
 # Minimum dependencies required to run the test suite.
-matplotlib = "*"
 parameterized = "*"
-pre-commit = "*"
-pytest-cov = "*"
 pytest = "*"
-ruff = "*"
+pytest-cov = "*"
+pytest-mpl = "*"
 
 [feature.test-example.dependencies]
 # Dependencies required to run the examples notebooks.
-pytest-xdist = "*"
 nbval = "*"
+pytest-xdist = "*"
 
-[feature.test.tasks]
-test-unit-cov = 'pytest -v colorcet --cov=colorcet --cov-append'
+[feature.test.dependencies]
+# Minimum dependencies required to run the test suite.
+matplotlib = "*"
+bokeh = "*"
+packaging = "*"
 
 [feature.test-core.tasks]
-test-unit = 'pytest -v colorcet'
+test-unit = 'pytest colorcet/tests'
 
 [feature.test-example.tasks]
 test-example = 'pytest -n logical --dist loadscope --nbval-lax -p no:python'
@@ -137,13 +125,12 @@ channels = [
     "pyviz/label/dev",
     # To get dev nbsite, not always needed.
     "pyviz/label/tooling_dev",
-    "conda-forge"
+    "conda-forge",
 ]
-dependencies = {nbsite = ">=0.8.6", sphinxext-rediraffe = "*"}
+dependencies = { nbsite = ">=0.8.6" }
 
 [feature.doc.activation.env]
 MOZ_HEADLESS = "1"
-MPLBACKEND = "Agg"
 DISPLAY = ":99.0"
 
 [feature.doc.tasks]
@@ -159,11 +146,9 @@ docs-build = { depends-on = ["_docs-install", "docs-build-sphinx"] }
 [feature.build.dependencies]
 python-build = "*"
 conda-build = "*"
-anaconda-client = "*"
 
 [feature.build.tasks]
 build-conda = 'bash scripts/conda/build.sh'
-publish-conda = 'anaconda'
 build-pip = 'python -m build .'
 
 # =================== LINT ====================

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,177 @@
+[project]
+name = "colorcet"
+channels = ["pyviz/label/dev",  "conda-forge"]
+platforms = ["linux-64", "osx-arm64", "osx-64", "win-64"]
+
+[environments]
+default = [
+    "py312",
+    "required",
+    "test-core",
+    "test",
+    "example",
+    "test-example",
+    "lint",
+    "dev",
+]
+
+[environments.test-39]
+features = ["py39", "required", "test-core", "test", "example", "test-example"]
+no-default-feature = true
+
+[environments.test-310]
+features = ["py310", "required", "test-core", "test", "example", "test-example"]
+no-default-feature = true
+
+[environments.test-311]
+features = ["py311", "required", "test-core", "test", "example", "test-example"]
+no-default-feature = true
+
+[environments.test-312]
+features = ["py312", "required", "test-core", "test", "example", "test-example"]
+no-default-feature = true
+
+[environments.test-core]
+features = ["py313", "required", "test-core"]
+no-default-feature = true
+
+[environments.docs]
+features = ["py311", "required", "doc", "example"]
+no-default-feature = true
+
+[environments.build]
+features = ["py311", "required", "build"]
+no-default-feature = true
+
+[environments.lint]
+features = ["lint"]
+no-default-feature = true
+
+[feature.required.dependencies]
+nomkl = "*"
+pip = "*"
+# Required
+bokeh = ">=3.1"
+holoviews = ">=1.19.0"
+numpy = ">=1.21"
+packaging = "*"
+panel = ">=1.0"
+param = ">=1.12.0,<3.0"
+
+[feature.required.tasks]
+install = 'python -m pip install --no-deps --disable-pip-version-check -e .'
+install-dev = { cmd = "pre-commit install", depends-on = ["install"] }
+setup-dev = { depends-on = ["install", "lint-install"] }
+sync-git-tags = 'python scripts/sync_git_tags.py colorcet'
+
+[feature.required.activation.env]
+PYTHONIOENCODING = "utf-8"
+
+[feature.py39.dependencies]
+python = "3.9.*"
+
+[feature.py310.dependencies]
+python = "3.10.*"
+
+[feature.py311.dependencies]
+python = "3.11.*"
+
+[feature.py312.dependencies]
+python = "3.12.*"
+
+[feature.py312.activation.env]
+COVERAGE_CORE = "sysmon"
+
+[feature.py313.dependencies]
+python = "3.13.*"
+
+[feature.py313.activation.env]
+COVERAGE_CORE = "sysmon"
+
+# =================== DEV ===================
+
+[feature.dev.dependencies]
+jupyterlab = "*"
+jupyterlab-myst = "*"
+setuptools_scm = ">=6"
+
+[feature.dev.tasks]
+lab = 'jupyter lab'
+
+# =================== SHARED DEPS ===================
+
+# Dependencies required to run the notebooks
+[feature.example.dependencies]
+datashader = ">=0.6.5"
+nbsite = ">=0.8.4"
+
+# =================== TESTS ===================
+
+[feature.test-core.dependencies]
+# Minimum dependencies required to run the test suite.
+matplotlib = "*"
+parameterized = "*"
+pre-commit = "*"
+pytest-cov = "*"
+pytest = "*"
+ruff = "*"
+
+[feature.test-example.dependencies]
+# Dependencies required to run the examples notebooks.
+pytest-xdist = "*"
+nbval = "*"
+
+[feature.test.tasks]
+test-unit-cov = 'pytest -v colorcet --cov=colorcet --cov-append'
+
+[feature.test-core.tasks]
+test-unit = 'pytest -v colorcet'
+
+[feature.test-example.tasks]
+test-example = 'pytest -n logical --dist loadscope --nbval-lax -p no:python'
+
+# =================== DOCS ====================
+
+[feature.doc]
+channels = [
+    # To get dev colorcet, not always needed.
+    "pyviz/label/dev",
+    # To get dev nbsite, not always needed.
+    "pyviz/label/tooling_dev",
+    "conda-forge"
+]
+dependencies = {nbsite = ">=0.8.6", sphinxext-rediraffe = "*"}
+
+[feature.doc.activation.env]
+MOZ_HEADLESS = "1"
+MPLBACKEND = "Agg"
+DISPLAY = ":99.0"
+
+[feature.doc.tasks]
+docs-build-sphinx = 'sphinx-build -b html doc builtdocs'
+_docs-install = 'python -m pip install --no-deps --disable-pip-version-check -e .'
+# Depends on _docs-install instead of install as install
+# in the default environment
+docs-build = { depends-on = ["_docs-install", "docs-build-sphinx"] }
+
+
+# ================== BUILD ====================
+
+[feature.build.dependencies]
+python-build = "*"
+conda-build = "*"
+anaconda-client = "*"
+
+[feature.build.tasks]
+build-conda = 'bash scripts/conda/build.sh'
+publish-conda = 'anaconda'
+build-pip = 'python -m build .'
+
+# =================== LINT ====================
+
+[feature.lint.dependencies]
+pre-commit = "*"
+
+[feature.lint.tasks]
+lint = 'pre-commit run --all-files'
+lint-install = 'pre-commit install'

--- a/pixi.toml
+++ b/pixi.toml
@@ -60,7 +60,6 @@ param = ">=1.12.0,<3.0"
 
 [feature.required.tasks]
 install = 'python -m pip install --no-deps --disable-pip-version-check -e .'
-install-dev = { cmd = "pre-commit install", depends-on = ["install"] }
 setup-dev = { depends-on = ["install", "lint-install"] }
 sync-git-tags = 'python scripts/sync_git_tags.py colorcet'
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,6 +10,10 @@ PYTHONIOENCODING = "utf-8"
 [environments]
 default = ["py312", "required", "test-core", "test", "example", "test-example", "lint", "dev"]
 
+[environments.test-38]
+features = ["py38", "required", "test-core", "test", "example", "test-example"]
+no-default-feature = true
+
 [environments.test-39]
 features = ["py39", "required", "test-core", "test", "example", "test-example"]
 no-default-feature = true
@@ -50,6 +54,9 @@ pip = "*"
 install = 'python -m pip install --no-deps --disable-pip-version-check -e .'
 setup-dev = { depends-on = ["install", "lint-install"] }
 sync-git-tags = 'python scripts/sync_git_tags.py colorcet'
+
+[feature.py38.dependencies]
+python = "3.8.*"
 
 [feature.py39.dependencies]
 python = "3.9.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version"]
 description = "Collection of perceptually uniform colormaps"
 readme = "README.md"
 license = { text = "CC-BY License" }
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 authors = [
     { name = "James A. Bednar", email = "jbednar@anaconda.com" },
 ]
@@ -22,8 +22,6 @@ classifiers = [
     "License :: OSI Approved",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -79,8 +77,7 @@ include-package-data = false
 include = ["colorcet"]
 
 [tool.setuptools_scm]
-# Replace with version_file when Python 3.7 is dropped.
-write_to = "colorcet/_version.py"
+version_file = "colorcet/_version.py"
 
 [tool.pytest.ini_options]
 addopts = "-v --pyargs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version"]
 description = "Collection of perceptually uniform colormaps"
 readme = "README.md"
 license = { text = "CC-BY License" }
-requires-python = ">=3.9"
+requires-python = ">=3.7"
 authors = [
     { name = "James A. Bednar", email = "jbednar@anaconda.com" },
 ]
@@ -22,6 +22,8 @@ classifiers = [
     "License :: OSI Approved",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -77,7 +79,8 @@ include-package-data = false
 include = ["colorcet"]
 
 [tool.setuptools_scm]
-version_file = "colorcet/_version.py"
+# Replace with version_file when Python 3.7 is dropped.
+write_to = "colorcet/_version.py"
 
 [tool.pytest.ini_options]
 addopts = ["--strict-config", "--strict-markers", "--color=yes"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,5 +80,7 @@ include = ["colorcet"]
 version_file = "colorcet/_version.py"
 
 [tool.pytest.ini_options]
-addopts = "-v --pyargs"
-norecursedirs = "doc .git dist build _build .ipynb_checkpoints"
+addopts = ["--strict-config", "--strict-markers", "--color=yes"]
+minversion = "7"
+xfail_strict = true
+log_cli_level = "INFO"

--- a/scripts/conda/build.sh
+++ b/scripts/conda/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+PACKAGE="colorcet"
+
+python -m build --sdist .
+
+VERSION=$(python -c "import $PACKAGE; print($PACKAGE._version.__version__)")
+export VERSION
+
+conda build scripts/conda/recipe --no-anaconda-upload --no-verify -c conda-forge --package-format 1
+
+mv "$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-$VERSION-py_0.tar.bz2" dist

--- a/scripts/conda/recipe/meta.yaml
+++ b/scripts/conda/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set pyproject = load_file_data('../pyproject.toml', from_recipe_dir=True) %}
+{% set pyproject = load_file_data('../../../pyproject.toml', from_recipe_dir=True) %}
 {% set buildsystem = pyproject['build-system'] %}
 {% set project = pyproject['project'] %}
 
@@ -10,7 +10,7 @@ package:
   version: {{ version }}
 
 source:
-  path: ..
+  url: ../../../dist/{{ name }}-{{ version }}.tar.gz
 
 build:
   noarch: python

--- a/scripts/sync_git_tags.py
+++ b/scripts/sync_git_tags.py
@@ -1,0 +1,32 @@
+"""
+Script to sync tags from upstream repository to forked repository
+"""
+
+import sys
+from subprocess import run
+
+
+def main(package: str) -> None:
+    origin = run(['git', 'remote', 'get-url', 'origin'], check=True, capture_output=True)
+    upstream = run(['git', 'remote', 'get-url', 'upstream'], check=False, capture_output=True)
+    url = (
+        f'https://github.com/holoviz/{package}.git'
+        if origin.stdout.startswith(b'http')
+        else f'git@github.com:holoviz/{package}.git'
+    )
+
+    if url == origin.stdout.strip().decode():
+        print('Not a forked repository, exiting.')
+        return
+    elif upstream.returncode:
+        print(f'Adding {url!r} as remote upstream')
+        run(['git', 'remote', 'add', 'upstream', url], check=True, capture_output=True)
+
+    print(f'Syncing tags from {package} repository with your forked repository')
+    run(['git', 'fetch', '--tags', 'upstream'], check=True, capture_output=True)
+    run(['git', 'push', '--tags'], check=True, capture_output=True)
+    print(f'Tags synced successfully with {origin.stdout.strip().decode()}')
+
+
+if __name__ == '__main__':
+    main(sys.argv[1])


### PR DESCRIPTION
This PR migrates the developer workflow to Pixi. This is aligned with what has already been done for holoviews and hvPlot:

- [x] Create `pixi.toml` to use approach adopted by hvPlot
- [x] Ensure the tests / docs / build workflow work as expected
- [x] Create the developer guide page in the docs

