### PR TITLE
Broken links: update Continuous.ipynb to fix broken link to test image.

### DIFF
--- a/doc/user_guide/Continuous.ipynb
+++ b/doc/user_guide/Continuous.ipynb
@@ -152,7 +152,7 @@
    "source": [
     "## Testing perceptual uniformity\n",
     "\n",
-    "Peter Kovesi created a [test image with a sine grating modulation of intensity](http://peterkovesi.com/projects/colourmaps/colourmaptestimage.html), where modulation gain decreases from top to bottom, which helps evaluate perceptual uniformity of a colormap at a glance.  The matplotlib maintainers use different definitions of perceptually uniform (uniformity in a different color space), but the new matplotlib perceptually uniform colormaps do well at Peter's test image:"
+    "Peter Kovesi created a [test image with a sine grating modulation of intensity](https://colorcet.com/testimage/index.html), where modulation gain decreases from top to bottom, which helps evaluate perceptual uniformity of a colormap at a glance.  The matplotlib maintainers use different definitions of perceptually uniform (uniformity in a different color space), but the new matplotlib perceptually uniform colormaps do well at Peter's test image:"
    ]
   },
   {


### PR DESCRIPTION
The Colorcet website currently has 1 broken link out of 119 url's in total.

The broken link: 

[sine grating modulation of intensity](http://peterkovesi.com/projects/colourmaps/colourmaptestimage.html)

http://peterkovesi.com/projects/colourmaps/colourmaptestimage.html ,

should be (as far as I can ascertain) be replaced with:

https://colorcet.com/testimage/index.html

Page: https://colorcet.holoviz.org/user_guide/Continuous.html

