### PR TITLE
chore!: Drop Python 3.9 EOL

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,7 +82,7 @@ jobs:
         run: |
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
-              "environment": ["test-39", "test-313", "test-314"],
+              "environment": ["test-310", "test-314"],
             }')
           echo "MATRIX=$MATRIX" >> $GITHUB_ENV
       - name: Set test matrix with 'full' option
@@ -90,7 +90,7 @@ jobs:
         run: |
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
-              "environment": ["test-39", "test-310", "test-311", "test-312", "test-313", "test-314"],
+              "environment": ["test-310", "test-311", "test-312", "test-313", "test-314"],
             }')
           echo "MATRIX=$MATRIX" >> $GITHUB_ENV
       - name: Set test matrix with 'downstream' option
@@ -119,8 +119,8 @@ jobs:
       - uses: holoviz-dev/holoviz_tasks/pixi_install@v0
         with:
           environments: test-314
-      - name: Run mypy - Python 3.9
-        run: pixi run type-mypy --python-version=3.9
+      - name: Run mypy - Python 3.10
+        run: pixi run type-mypy --python-version=3.10
       - name: Run mypy - Python 3.14
         run: pixi run type-mypy --python-version=3.14
       - name: Run TY

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ by Peter Kovesi at the Center for Exploration Targeting.
 
 ## Installation
 
-Colorcet supports Python 3.9 and greater on Linux, Windows, or Mac
+Colorcet supports Python 3.10 and greater on Linux, Windows, and Mac
 and can be installed with conda:
 
 ```sh

--- a/colorcet/plotting.py
+++ b/colorcet/plotting.py
@@ -5,7 +5,7 @@ documentation.
 """
 
 from collections.abc import Sequence
-from typing import Any, Optional, Union
+from typing import Any
 
 import holoviews as hv
 import matplotlib.colors as mcolors
@@ -20,8 +20,8 @@ array = np.meshgrid(np.linspace(0, 1, 256), np.linspace(0, 1, 10))[0]
 
 def swatch(
     name: str,
-    cmap: Optional[Union[Sequence[str], mcolors.Colormap]] = None,
-    bounds: Optional[tuple[float, float, float, float]] = None,
+    cmap: Sequence[str] | mcolors.Colormap | None = None,
+    bounds: tuple[float, float, float, float] | None = None,
     array: np.ndarray[Any, Any] = array,
     **kwargs: Any,
 ) -> hv.Image:
@@ -64,11 +64,11 @@ def swatch(
 
 
 def swatches(
-    *args: Union[str, tuple[Any, ...]],
-    group: Optional[Union[str, list[str]]] = None,
-    not_group: Optional[Union[str, list[str]]] = None,
+    *args: str | tuple[Any, ...],
+    group: str | list[str] | None = None,
+    not_group: str | list[str] | None = None,
     only_aliased: bool = False,
-    cols: Optional[int] = None,
+    cols: int | None = None,
     **kwargs: Any,
 ) -> hv.Layout:
     """Show swatches for given names or names in group"""
@@ -102,7 +102,7 @@ def swatches(
 
 sine = sineramp()
 
-def sine_comb(name: str, cmap: Optional[Any] = None, **kwargs: Any) -> hv.Image:
+def sine_comb(name: str, cmap: Any | None = None, **kwargs: Any) -> hv.Image:
     """Show sine_comb using matplotlib or bokeh via holoviews"""
     title = name if cmap else get_aliases(name)
     plot = hv.Image(sine, group=title)
@@ -119,9 +119,9 @@ def sine_comb(name: str, cmap: Optional[Any] = None, **kwargs: Any) -> hv.Image:
 
 
 def sine_combs(
-    *args: Union[str, tuple[Any, ...]],
-    group: Optional[Union[str, list[str]]] = None,
-    not_group: Optional[Union[str, list[str]]] = None,
+    *args: str | tuple[Any, ...],
+    group: str | list[str] | None = None,
+    not_group: str | list[str] | None = None,
     only_aliased: bool = False,
     cols: int = 1,
     **kwargs: Any,
@@ -149,7 +149,7 @@ xx, yy = np.meshgrid(np.arange(0,10), np.arange(0,10))
 data = np.array([xx, yy, zz]).transpose().reshape(100, 3)
 
 
-def candy_buttons(name: str, cmap: Optional[Any] = None, size: int = 450, **kwargs: Any) -> hv.Points:
+def candy_buttons(name: str, cmap: Any | None = None, size: int = 450, **kwargs: Any) -> hv.Points:
     if cmap is None:
         cmap = palette[name][:100]
         name = get_aliases(name)

--- a/colorcet/sineramp.py
+++ b/colorcet/sineramp.py
@@ -103,13 +103,13 @@ July  2013  Original version.
 March 2014  Adjustments to make it better for evaluating cyclic colour maps.
 June  2014  Default wavelength changed from 10 to 8.
 """
-from typing import Any, Union
+from typing import Any
 
 import numpy as np
 
 
 def sineramp(
-    size: Union[tuple[int], tuple[int,int]] = (256, 512),
+    size: tuple[int] | tuple[int, int] = (256, 512),
     amp: float = 12.5,
     wavelen: int = 8,
     p: float = 2,

--- a/pixi.toml
+++ b/pixi.toml
@@ -37,11 +37,11 @@ features = ["py313", "required", "test-core", "test", "example", "test-example"]
 no-default-feature = true
 
 [environments.test-314]
-features = ["py314", "required", "test-core-314"]
+features = ["py314", "required", "test-core", "test", "example", "test-example"]
 no-default-feature = true
 
 [environments.test-core]
-features = ["py313", "required", "test-core"]
+features = ["py314", "required", "test-core"]
 no-default-feature = true
 
 [environments.docs]
@@ -116,16 +116,6 @@ parameterized = "*"
 pytest = "*"
 pytest-cov = "*"
 pytest-mpl = "*"
-
-[feature.test-core-314.dependencies]
-# Minimum dependencies required to run the test suite.
-parameterized = "*"
-pytest = "*"
-pytest-cov = "*"
-# pytest-mpl = "*"
-
-[feature.test-core-314.tasks]
-test-unit = 'pytest colorcet/tests'
 
 [feature.test-example.dependencies]
 # Dependencies required to run the examples notebooks.

--- a/pixi.toml
+++ b/pixi.toml
@@ -20,10 +20,6 @@ default = [
     "type",
 ]
 
-[environments.test-39]
-features = ["py39", "required", "test-core", "test", "example", "test-example"]
-no-default-feature = true
-
 [environments.test-310]
 features = ["py310", "required", "test-core", "test", "example", "test-example"]
 no-default-feature = true
@@ -68,9 +64,6 @@ pip = "*"
 install = 'python -m pip install --no-deps --disable-pip-version-check -e .'
 setup-dev = { depends-on = ["install", "lint-install"] }
 sync-git-tags = 'python scripts/sync_git_tags.py colorcet'
-
-[feature.py39.dependencies]
-python = "3.9.*"
 
 [feature.py310.dependencies]
 python = "3.10.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version"]
 description = "Collection of perceptually uniform colormaps"
 readme = "README.md"
 license = { text = "CC-BY License" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "James A. Bednar", email = "jbednar@anaconda.com" },
 ]
@@ -22,7 +22,6 @@ classifiers = [
     "License :: OSI Approved",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
## Description

<!--
Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme

- Summarize the change and which issue is fixed.
- Include relevant motivation and context.
- Add visuals when possible, e.g. before/after screenshots with full code snippets.
-->

Python 3.9 has been EOL since October, this drop support for it.

Code changes are related to pyupgrade.

Also clean up Python 3.14 CI settings as these no longer need special handling.  

## How Has This Been Tested?

CI